### PR TITLE
Pump version

### DIFF
--- a/information/README.md
+++ b/information/README.md
@@ -5,7 +5,7 @@
 
 * Layer 1: Sepolia testnet
 * storage-contracts-v1: v0.1.0
-* es-node: v0.1.15
+* es-node: v0.1.16
 
 ## Public Testnet 1 Deployment
 

--- a/storage-provider-guide/storage-provider-faq.md
+++ b/storage-provider-guide/storage-provider-faq.md
@@ -112,7 +112,7 @@ docker run --name es  -d  \
           -p 9222:9222 \
           -p 30305:30305/udp \
           --entrypoint /es-node/run.sh \
-          ghcr.io/ethstorage/es-node:v0.1.15 \
+          ghcr.io/ethstorage/es-node:v0.1.16 \
           --p2p.max.request.size 1048576
 ```
 
@@ -171,17 +171,17 @@ Firstly, you can [review the changes between releases](https://github.com/ethsto
 
 1. "Ctrl C" to stop the es-node process. 
 
-2. Download new version (e.g., `es-node.v0.1.15`) of the pre-built package suitable for your platform using commands [here](/storage-provider-guide/tutorials.md#from-pre-built-executables).
+2. Download new version (e.g., `es-node.v0.1.16`) of the pre-built package suitable for your platform using commands [here](/storage-provider-guide/tutorials.md#from-pre-built-executables).
 
-3. Some files including data folder need to be moved from the directory of old build (e.g., `es-node.v0.1.14`) to the new one:
+3. Some files including data folder need to be moved from the directory of old build (e.g., `es-node.v0.1.15`) to the new one:
 
 ```sh
-# replace v0.1.15 to your target version
-cd es-node.v0.1.15
+# replace v0.1.16 to your target version
+cd es-node.v0.1.16
 
-# replace v0.1.14 to the version you have
-mv ../es-node.v0.1.14/es-data .
-mv ../es-node.v0.1.14/esnode_* .
+# replace v0.1.15 to the version you have
+mv ../es-node.v0.1.15/es-data .
+mv ../es-node.v0.1.15/esnode_* .
 ```
 4. Launch es-node using the same command as the one previously used.
 
@@ -206,7 +206,7 @@ docker run --name es -d \
           -p 9222:9222 \
           -p 30305:30305/udp \
           --entrypoint /es-node/run.sh \
-          ghcr.io/ethstorage/es-node:v0.1.15 \
+          ghcr.io/ethstorage/es-node:v0.1.16 \
           --l1.rpc <el_rpc> \
           --l1.beacon <cl_rpc>
 ```
@@ -215,7 +215,7 @@ docker run --name es -d \
 
 1. "Ctrl C" to stop the es-node process. 
 
-2. Switch to the correct branch of the source code (e.g., you want to move to `v0.1.15`):
+2. Switch to the correct branch of the source code (e.g., you want to move to `v0.1.16`):
 
 ```sh
 cd es-node
@@ -223,8 +223,8 @@ cd es-node
 # fetch new branches
 git fetch
 
-# replace 'v0.1.15' to your target version
-git checkout v0.1.15
+# replace 'v0.1.16' to your target version
+git checkout v0.1.16
 ```
 3. build and launch es-node
 

--- a/storage-provider-guide/tutorials.md
+++ b/storage-provider-guide/tutorials.md
@@ -31,7 +31,7 @@ This guide provides practical steps for the storage providers to start an es-nod
 
 * MacOS Version 14+, Ubuntu 20.04+, or Windows with WSL (Windows Subsystem for Linux) version 2
 * (Optional) Docker 24.0.5+ (would simplify the process)
-* (Optional) Go 1.20+ and Node.js 16+ (can be installed following the [steps](tutorials.md#install-dependencies))
+* (Optional) Go 1.21+ and Node.js 16+ (can be installed following the [steps](tutorials.md#install-dependencies))
 
 > ℹ️ **_Note:_** The steps assume the use of the root user for all command line operations. If using a non-root user, you may need to prepend some commands with "sudo".
 

--- a/storage-provider-guide/tutorials.md
+++ b/storage-provider-guide/tutorials.md
@@ -92,22 +92,22 @@ Download the pre-built package suitable for your platform:
 - Linux x86-64 or WSL:
 
 ```sh
-curl -L https://github.com/ethstorage/es-node/releases/download/v0.1.15/es-node.v0.1.15.linux-amd64.tar.gz | tar -xz
+curl -L https://github.com/ethstorage/es-node/releases/download/v0.1.16/es-node.v0.1.16.linux-amd64.tar.gz | tar -xz
 ```
 
 - MacOS x86-64:
 
 ```sh
-curl -L https://github.com/ethstorage/es-node/releases/download/v0.1.15/es-node.v0.1.15.darwin-amd64.tar.gz | tar -xz
+curl -L https://github.com/ethstorage/es-node/releases/download/v0.1.16/es-node.v0.1.16.darwin-amd64.tar.gz | tar -xz
 ```
 
 - MacOS ARM64:
 
 ```sh
-curl -L https://github.com/ethstorage/es-node/releases/download/v0.1.15/es-node.v0.1.15.darwin-arm64.tar.gz | tar -xz
+curl -L https://github.com/ethstorage/es-node/releases/download/v0.1.16/es-node.v0.1.16.darwin-arm64.tar.gz | tar -xz
 ```
 
-In folder `es-node.v0.1.15`, init es-node by running:
+In folder `es-node.v0.1.16`, init es-node by running:
 
 ```
 env ES_NODE_STORAGE_MINER=<miner> ./init.sh --l1.rpc <el_rpc>
@@ -129,7 +129,7 @@ docker run --rm \
           -v ./zkey:/es-node/build/bin/snark_lib/zkey \
           -e ES_NODE_STORAGE_MINER=<miner> \
           --entrypoint /es-node/init.sh \
-          ghcr.io/ethstorage/es-node:v0.1.15 \
+          ghcr.io/ethstorage/es-node:v0.1.16 \
           --l1.rpc <el_rpc>
 ```
 
@@ -145,7 +145,7 @@ docker run --name es -d \
           -p 9222:9222 \
           -p 30305:30305/udp \
           --entrypoint /es-node/run.sh \
-          ghcr.io/ethstorage/es-node:v0.1.15 \
+          ghcr.io/ethstorage/es-node:v0.1.16 \
           --l1.rpc <el_rpc> \
           --l1.beacon <cl_rpc>
 ```
@@ -181,7 +181,7 @@ Now download source code and switch to the latest release branch:
 ```sh
 git clone https://github.com/ethstorage/es-node.git
 cd es-node
-git checkout v0.1.15
+git checkout v0.1.16
 ```
 
 Build es-node:


### PR DESCRIPTION
Note go version pumped to 1.21 required by `github.com/tetratelabs/wazero v1.8.0` used by go-rapidsnark