### PR TITLE
sepolia add ethstorage-sdk@2

### DIFF
--- a/dapp-developer-guide/tutorials/use-ethstorage-sdk-to-upload-and-download-files.md
+++ b/dapp-developer-guide/tutorials/use-ethstorage-sdk-to-upload-and-download-files.md
@@ -14,9 +14,14 @@ You can easily switch to other chains by specify a different RPC endpoint, such 
 
 You can install `ethstorage-sdk` by the following command:
 
-```sh
-npm i ethstorage-sdk
-```
+- For the **Sepolia network**, install version 2:
+    ```sh
+    npm i ethstorage-sdk@2
+    ```
+- For other networks, install the latest version normally:
+    ```sh
+    npm i ethstorage-sdk
+    ```
 
 ## Step 2: Manage Files
 


### PR DESCRIPTION
Because the sepolia network _ethstorage_ contract has not been upgraded, it does not support the op blob mode in the latest SDK, so a lower version needs to be installed.