### PR TITLE
Delete the ethstorage-sdk distinction text.

### DIFF
--- a/dapp-developer-guide/tutorials/use-ethstorage-sdk-to-upload-and-download-files.md
+++ b/dapp-developer-guide/tutorials/use-ethstorage-sdk-to-upload-and-download-files.md
@@ -14,16 +14,8 @@ You can easily switch to other chains by specify a different RPC endpoint, such 
 
 You can install `ethstorage-sdk` by the following command:
 
-### SWC Beta
-
 ```bash
  npm i ethstorage-sdk
-```
-
-### Sepolia
-
-```bash
- npm i ethstorage-sdk@2
 ```
 
 ## Step 2: Manage Files


### PR DESCRIPTION
Now the files uploaded by _ethstorage-sdk_ can be accessed by sepolia and swc, so the distinguishing text is deleted.